### PR TITLE
refactor: single source of truth via include-markdown plugin

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
+      - "LICENSE"
+      - "schemas/**"
   workflow_dispatch:
 
 permissions:
@@ -28,8 +33,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install MkDocs Material
-        run: pip install mkdocs-material
+      - name: Install MkDocs Material and plugins
+        run: pip install mkdocs-material mkdocs-include-markdown-plugin mkdocs-schema-reader
 
       - name: Build site
         run: mkdocs build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,64 @@
-# Contributing
+# Contributing to Story as Code Spec
 
-See the full contributing guide in the [documentation](https://christopherscholz.github.io/story-as-code-spec/contributing/).
+<!-- contributing-start -->
+Thank you for your interest in contributing to the Story as Code specification! This document explains how to participate.
+
+## How to Contribute
+
+### Discussions
+
+For questions, ideas, and general feedback, use [GitHub Discussions](https://github.com/christopherscholz/story-as-code-spec/discussions). This is the best place to start before opening an issue or pull request.
+
+### Issues
+
+- **Spec changes** — Propose modifications to the specification
+- **Bug reports** — Report schema errors or inconsistencies
+- **Feature requests** — Suggest new concepts or schema extensions
+
+### Pull Requests
+
+1. Fork the repository
+2. Create a branch from `main`
+3. Make your changes
+4. Ensure YAML files pass validation (`yamllint`)
+5. Submit a pull request
+
+## Commit Conventions
+
+This project uses semantic commit messages with the following scopes:
+
+| Scope | Description |
+|-------|-------------|
+| `graph` | Node, edge, or frame changes |
+| `schema` | Schema definitions and type changes |
+| `constraint` | World rule changes |
+| `lens` | Narrative perspective changes |
+| `arc` | Story arc changes |
+| `format` | Output format changes |
+| `derive` | Derivation-related changes |
+| `meta` | Repository metadata, CI, docs |
+
+Example: `feat(schema): add magic system node types`
+
+## Schema Extension Process
+
+To propose a new schema extension:
+
+1. Open an issue describing the use case
+2. Draft the schema YAML following the existing patterns in `schemas/`
+3. Include example node/edge definitions that use your schema
+4. Submit a pull request for review
+
+## Spec Change Process
+
+Changes to the core specification (`docs/spec.md`) require:
+
+1. An issue describing the motivation and proposed change
+2. Discussion in the issue or in Discussions
+3. A pull request with the spec change and any affected schema updates
+4. Review and approval
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code.
+<!-- contributing-end -->

--- a/README.md
+++ b/README.md
@@ -4,17 +4,103 @@
 [![Spec Version](https://img.shields.io/badge/Spec-v0.1.0_Draft-orange.svg)](docs/spec.md)
 [![GitHub Pages](https://img.shields.io/badge/Docs-GitHub_Pages-brightgreen.svg)](https://christopherscholz.github.io/story-as-code-spec/)
 
+<!-- content-start -->
 > Declarative YAML specification for defining fictional worlds as temporal graphs and deriving narratives from them.
 
+## What is Story as Code?
+
 Story as Code treats fictional worlds as **source code** — structured, versioned, and compilable. Instead of writing narratives directly, you declare a world graph of characters, locations, events, and their relationships. Narratives are then **derived** from this graph through lenses, arcs, and formats.
+
+Think of it like a compiler: the world graph is your source, the narrative is your compiled output.
+
+### Core Principles
+
+- **Git-native** — Worlds are Git repositories with semantic commit conventions
+- **Declarative** — The graph declares what exists and when; narratives are derived, never primary
+- **Temporally rich** — Time is graph topology, supporting branches, loops, and retrocausality
+- **Schema-flexible** — The type system is extensible for custom world rules
+- **Format-agnostic** — Same world can produce prose, screenplays, comics, audio, or interactive narratives
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Nodes** | Entities in the world — characters, locations, objects, events, concepts |
+| **Edges** | Relationships and connections between nodes |
+| **Frames** | Temporal contexts with different topologies (linear, branching, cyclical) |
+| **Lenses** | Narrative perspective configurations — who tells the story, how, and what they know |
+| **Arcs** | Dramatic structure definitions with milestones and conditions |
+| **Formats** | Output structure (novel, screenplay, comic) with pacing rules |
+| **Derivations** | Compiled narrative outputs linked back to the graph |
+
+## Quick Start
+
+A minimal world consists of a `world.yaml` and node files:
+
+```yaml
+# world.yaml
+id: "world_fairy_tale"
+name: "A Simple Fairy Tale"
+version: "0.1.0"
+default_frame: "frame_main"
+schemas:
+  - schema_core
+```
+
+```yaml
+# graph/nodes/character/hero.yaml
+id: "char_hero"
+type: CHARACTER
+name: "The Hero"
+states:
+  - frame: "frame_main"
+    at: "T:0"
+    properties:
+      age: 18
+      location: "loc_village"
+      trait_courage: 0.8
+```
+
+```yaml
+# graph/edges/quest_begins.yaml
+id: "edge_quest"
+type: ACTION
+subtype: INITIATES
+source: "char_hero"
+target: "evt_quest_start"
+frame: "frame_main"
+at: "T:1"
+```
+
+## Repository Structure
+
+```
+world.yaml                    # Root metadata
+graph/
+  nodes/{type}/              # One YAML file per entity
+  edges/                     # Relationships between entities
+  frames/                    # Temporal frame definitions
+schemas/                     # Type definitions and constraints
+  schema_core.yaml           # Built-in types
+constraints/                 # World rules
+lenses/                      # Narrative perspective configs
+arcs/                        # Story arc definitions
+formats/                     # Output format definitions
+derivations/                 # Generated narrative content
+```
+
+## Status
+
+This specification is in **Draft v0.1.0**. The core concepts are defined but subject to change. Feedback and contributions are welcome.
+<!-- content-end -->
 
 ## Documentation
 
 Read the full documentation at **[christopherscholz.github.io/story-as-code-spec](https://christopherscholz.github.io/story-as-code-spec/)**.
 
-## Status
+## Contributing
 
-This specification is in **Draft v0.1.0**. Feedback and contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to participate in the development of this specification.
 
 ## License
 

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,3 @@
+{%
+  include-markdown "../CODE_OF_CONDUCT.md"
+%}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,62 +1,7 @@
-# Contributing to Story as Code Spec
+# Contributing
 
-Thank you for your interest in contributing to the Story as Code specification! This document explains how to participate.
-
-## How to Contribute
-
-### Discussions
-
-For questions, ideas, and general feedback, use [GitHub Discussions](https://github.com/christopherscholz/story-as-code-spec/discussions). This is the best place to start before opening an issue or pull request.
-
-### Issues
-
-- **Spec changes** — Propose modifications to the specification
-- **Bug reports** — Report schema errors or inconsistencies
-- **Feature requests** — Suggest new concepts or schema extensions
-
-### Pull Requests
-
-1. Fork the repository
-2. Create a branch from `main`
-3. Make your changes
-4. Ensure YAML files pass validation (`yamllint`)
-5. Submit a pull request
-
-## Commit Conventions
-
-This project uses semantic commit messages with the following scopes:
-
-| Scope | Description |
-|-------|-------------|
-| `graph` | Node, edge, or frame changes |
-| `schema` | Schema definitions and type changes |
-| `constraint` | World rule changes |
-| `lens` | Narrative perspective changes |
-| `arc` | Story arc changes |
-| `format` | Output format changes |
-| `derive` | Derivation-related changes |
-| `meta` | Repository metadata, CI, docs |
-
-Example: `feat(schema): add magic system node types`
-
-## Schema Extension Process
-
-To propose a new schema extension:
-
-1. Open an issue describing the use case
-2. Draft the schema YAML following the existing patterns in `schemas/`
-3. Include example node/edge definitions that use your schema
-4. Submit a pull request for review
-
-## Spec Change Process
-
-Changes to the core specification (`docs/spec.md`) require:
-
-1. An issue describing the motivation and proposed change
-2. Discussion in the issue or in Discussions
-3. A pull request with the spec change and any affected schema updates
-4. Review and approval
-
-## Code of Conduct
-
-This project follows the [Contributor Covenant Code of Conduct](https://github.com/christopherscholz/story-as-code-spec/blob/main/CODE_OF_CONDUCT.md). By participating, you agree to uphold this code.
+{%
+  include-markdown "../CONTRIBUTING.md"
+  start="<!-- contributing-start -->"
+  end="<!-- contributing-end -->"
+%}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,64 +1,7 @@
 # Story as Code
 
-> Declarative YAML specification for defining fictional worlds as temporal graphs and deriving narratives from them.
-
-## What is Story as Code?
-
-Story as Code treats fictional worlds as **source code** — structured, versioned, and compilable. Instead of writing narratives directly, you declare a world graph of characters, locations, events, and their relationships. Narratives are then **derived** from this graph through lenses, arcs, and formats.
-
-Think of it like a compiler: the world graph is your source, the narrative is your compiled output.
-
-### Core Principles
-
-- **Git-native** — Worlds are Git repositories with semantic commit conventions
-- **Declarative** — The graph declares what exists and when; narratives are derived, never primary
-- **Temporally rich** — Time is graph topology, supporting branches, loops, and retrocausality
-- **Schema-flexible** — The type system is extensible for custom world rules
-- **Format-agnostic** — Same world can produce prose, screenplays, comics, audio, or interactive narratives
-
-## Key Concepts
-
-| Concept | Description |
-|---------|-------------|
-| **Nodes** | Entities in the world — characters, locations, objects, events, concepts |
-| **Edges** | Relationships and connections between nodes |
-| **Frames** | Temporal contexts with different topologies (linear, branching, cyclical) |
-| **Lenses** | Narrative perspective configurations — who tells the story, how, and what they know |
-| **Arcs** | Dramatic structure definitions with milestones and conditions |
-| **Formats** | Output structure (novel, screenplay, comic) with pacing rules |
-| **Derivations** | Compiled narrative outputs linked back to the graph |
-
-## Quick Start
-
-A minimal world consists of a `world.yaml` and node files:
-
-```yaml
-# world.yaml
-id: "world_fairy_tale"
-name: "A Simple Fairy Tale"
-version: "0.1.0"
-default_frame: "frame_main"
-schemas:
-  - schema_core
-```
-
-```yaml
-# graph/nodes/character/hero.yaml
-id: "char_hero"
-type: CHARACTER
-name: "The Hero"
-states:
-  - frame: "frame_main"
-    at: "T:0"
-    properties:
-      age: 18
-      location: "loc_village"
-```
-
-## Status
-
-This specification is in **Draft v0.1.0**. Read the full [Specification](spec.md) for details.
-
-## Contributing
-
-See [Contributing](contributing.md) for how to participate in the development of this specification.
+{%
+  include-markdown "../README.md"
+  start="<!-- content-start -->"
+  end="<!-- content-end -->"
+%}

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,3 @@
+{%
+  include-markdown "../LICENSE"
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: Declarative YAML specification for defining fictional worlds a
 site_url: https://christopherscholz.github.io/story-as-code-spec/
 repo_url: https://github.com/christopherscholz/story-as-code-spec
 repo_name: christopherscholz/story-as-code-spec
-edit_uri: edit/main/docs/
+edit_uri: edit/main/
 
 theme:
   name: material
@@ -31,6 +31,10 @@ theme:
 
 plugins:
   - search
+  - include-markdown
+  - schema_reader:
+      include:
+        - "schemas"
 
 markdown_extensions:
   - tables
@@ -49,6 +53,8 @@ nav:
   - Home: index.md
   - Specification: spec.md
   - Contributing: contributing.md
+  - Code of Conduct: code-of-conduct.md
+  - License: license.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary
- Root files (README.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE) are the **single source of truth**
- `docs/` pages include them via `mkdocs-include-markdown-plugin` using HTML comment markers
- No content duplication, no symlinks
- Added `mkdocs-schema-reader` plugin for auto-generated schema documentation from `schemas/`
- Deploy workflow updated to install plugins and trigger on root file changes

## Changes
- **mkdocs.yml** — Added `include-markdown` and `schema_reader` plugins, expanded nav
- **README.md** — Full content with `<!-- content-start/end -->` markers
- **CONTRIBUTING.md** — Full content with `<!-- contributing-start/end -->` markers
- **docs/index.md** — Includes README.md content section
- **docs/contributing.md** — Includes CONTRIBUTING.md content
- **docs/code-of-conduct.md** — Includes CODE_OF_CONDUCT.md (new)
- **docs/license.md** — Includes LICENSE (new)
- **deploy-pages.yml** — Installs new plugins, triggers on root files and schemas/

## Test plan
- [ ] GitHub Pages builds and deploys successfully
- [ ] docs/index.md renders README content correctly
- [ ] docs/contributing.md renders CONTRIBUTING content correctly
- [ ] Code of Conduct and License pages render correctly
- [ ] README.md displays correctly on GitHub repo landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)