### PR TITLE
meta: add CODEOWNERS for future code review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owner for everything in the repo.
+# Activate "Require review from Code Owners" in branch protection
+# once a second maintainer joins the project.
+* @christopherscholz


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `@christopherscholz` as default owner for all files
- Prepares the repo for required code-owner reviews once a second maintainer joins
- Review requirements are currently disabled in branch protection to avoid self-review friction

## Context
Branch protection has been updated to:
- Only allow squash merges (merge commits and rebase disabled)
- Auto-delete feature branches after merge
- Enforce rules for admins
- Remove required PR reviews (solo maintainer)

## Test plan
- [x] Verify CODEOWNERS syntax is valid
- [x] Verify branch protection settings are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)