### PR TITLE
feat: add YAML schema definitions for spec v0.1.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,6 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Specification: spec.md
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md
   - License: license.md

--- a/schemas/arc.schema.yaml
+++ b/schemas/arc.schema.yaml
@@ -1,0 +1,112 @@
+# Story as Code – Story Arc Schema
+# Defines the structure of story arc files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/arc/v0.1.0"
+type: object
+required:
+  - id
+  - name
+  - milestones
+
+properties:
+  id:
+    type: string
+    pattern: "^arc_"
+    description: "Unique arc identifier"
+
+  name:
+    type: string
+    description: "Human-readable arc name"
+
+  milestones:
+    type: array
+    items:
+      $ref: "#/$defs/Milestone"
+
+  interleaves_with:
+    type: array
+    items:
+      type: string
+      pattern: "^arc_"
+    description: "Other arcs running simultaneously"
+
+  conflict_points:
+    type: array
+    items:
+      type: object
+      properties:
+        at:
+          type: string
+          pattern: "^ms_"
+        with:
+          type: string
+          description: "arc_id.milestone_id"
+        tension_type:
+          type: string
+          enum:
+            - OPPOSED_GOALS
+            - SHARED_RESOURCE
+            - MUTUAL_DEPENDENCY
+            - IRONIC_PARALLEL
+
+$defs:
+  Milestone:
+    type: object
+    required:
+      - id
+      - position
+      - name
+      - graph_conditions
+    properties:
+      id:
+        type: string
+        pattern: "^ms_"
+        description: "Unique milestone identifier within the arc"
+      position:
+        type: string
+        description: "Range within the story (0.0-1.0), e.g., '0.15-0.30'"
+      name:
+        type: string
+        description: "Human-readable milestone name"
+      graph_conditions:
+        type: array
+        items:
+          $ref: "#/$defs/GraphCondition"
+      emotional_target:
+        type: object
+        properties:
+          valence:
+            type: number
+            minimum: -1.0
+            maximum: 1.0
+          arousal:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+      tension:
+        type: string
+        enum:
+          - LOW
+          - RISING
+          - HIGH
+          - MAXIMUM
+          - FALLING
+          - RESOLVED
+      depends_on:
+        type: array
+        items:
+          type: string
+          pattern: "^ms_"
+      generates:
+        type: array
+        items:
+          type: object
+          description: "New graph elements this milestone introduces"
+
+  GraphCondition:
+    type: object
+    description: >
+      Declarative assertion about graph state.
+      Supported condition types: edge_exists, edge_not_exists, node_state, OR, AND, NOT
+    additionalProperties: true

--- a/schemas/constraint.schema.yaml
+++ b/schemas/constraint.schema.yaml
@@ -1,0 +1,48 @@
+# Story as Code – Constraint Schema
+# Defines the structure of constraint (world rule) files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/constraint/v0.1.0"
+type: object
+required:
+  - id
+  - name
+  - rule
+  - severity
+
+properties:
+  id:
+    type: string
+    pattern: "^constraint_"
+    description: "Unique constraint identifier"
+
+  name:
+    type: string
+    description: "Human-readable rule name"
+
+  schema:
+    type: string
+    pattern: "^schema_"
+    description: "Schema this constraint belongs to"
+
+  rule:
+    type: string
+    description: >
+      Constraint expression using the declarative query language.
+      Syntax: FOR node IN nodes WHERE condition: assertion
+      Supports: COUNT, edges, nodes, GROUP BY, comparison operators
+
+  severity:
+    type: string
+    enum:
+      - ERROR
+      - WARNING
+      - INFO
+    description: >
+      ERROR: blocks commit.
+      WARNING: flags issue but allows commit.
+      INFO: suggestion only.
+
+  on_violation:
+    type: string
+    description: "Human-readable message template for violations. Supports {node.name}, {count} placeholders."

--- a/schemas/derivation-meta.schema.yaml
+++ b/schemas/derivation-meta.schema.yaml
@@ -1,0 +1,154 @@
+# Story as Code – Derivation Meta Schema
+# Defines the structure of .meta.yaml files (validation contracts)
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/derivation-meta/v0.1.0"
+type: object
+required:
+  - id
+  - derived_from_commit
+  - derived_at
+  - lens
+  - format
+  - dependencies
+
+properties:
+  id:
+    type: string
+    description: "Derivation identifier"
+
+  derived_from_commit:
+    type: string
+    description: "Git commit hash of the graph state used"
+
+  derived_at:
+    type: string
+    format: date-time
+    description: "Timestamp of generation"
+
+  lens:
+    type: string
+    pattern: "^lens_"
+    description: "Lens ID used"
+
+  format:
+    type: string
+    pattern: "^fmt_"
+    description: "Format ID used"
+
+  arc_position:
+    type: object
+    properties:
+      arc:
+        type: string
+        pattern: "^arc_"
+      milestone:
+        type: string
+        pattern: "^ms_"
+      progress:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+
+  dependencies:
+    type: object
+    properties:
+      nodes:
+        type: array
+        items:
+          $ref: "#/$defs/NodeDependency"
+      edges:
+        type: array
+        items:
+          $ref: "#/$defs/EdgeDependency"
+      reveals:
+        type: array
+        items:
+          $ref: "#/$defs/RevealDependency"
+
+  continuity:
+    type: object
+    properties:
+      previous:
+        type: string
+        description: "ID of the previous scene's derivation"
+      next:
+        type: string
+        description: "ID of the next scene's derivation"
+
+  validation:
+    type: object
+    properties:
+      status:
+        type: string
+        enum:
+          - VALID
+          - DRIFT
+          - BROKEN
+      last_checked:
+        type: string
+        description: "Commit hash of last validation"
+      issues:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+            severity:
+              type: string
+              enum: [ERROR, WARNING, INFO]
+            message:
+              type: string
+            affected_node:
+              type: string
+
+$defs:
+  NodeDependency:
+    type: object
+    required:
+      - id
+      - must_exist
+    properties:
+      id:
+        type: string
+      must_exist:
+        type: boolean
+      required_state:
+        type: object
+        properties:
+          at:
+            type: object
+            properties:
+              frame:
+                type: string
+              T:
+                type: integer
+          properties:
+            type: object
+            additionalProperties: true
+
+  EdgeDependency:
+    type: object
+    required:
+      - id
+      - must_exist
+    properties:
+      id:
+        type: string
+      must_exist:
+        type: boolean
+      required:
+        type: object
+        additionalProperties: true
+
+  RevealDependency:
+    type: object
+    properties:
+      node:
+        type: string
+      revealed_to:
+        type: string
+      at:
+        type: string
+        pattern: "^T\\d+$"

--- a/schemas/edge.schema.yaml
+++ b/schemas/edge.schema.yaml
@@ -1,0 +1,115 @@
+# Story as Code – Edge Schema
+# Defines the structure of edge files (relationships between nodes)
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/edge/v0.1.0"
+type: object
+required:
+  - id
+  - type
+  - source
+  - target
+  - valid_in
+
+properties:
+  id:
+    type: string
+    pattern: "^edge_[a-z0-9_]+$"
+    description: "Unique identifier. Convention: edge_{short_hash}"
+
+  type:
+    type: string
+    enum:
+      - RELATIONSHIP
+      - ACTION
+      - SPATIAL
+      - KNOWLEDGE
+      - MEMBERSHIP
+    description: "Edge type. Can be extended by custom schemas."
+
+  subtype:
+    type: string
+    description: >
+      Specific relationship subtype. Built-in subtypes include:
+      RELATIONSHIP: LOVES, HATES, TRUSTS, FEARS, SERVES, MENTORS, RIVALS
+      ACTION: CREATED, DESTROYED, VISITED, STOLE, GAVE, KILLED, SAVED
+      SPATIAL: LOCATED_AT, PART_OF, CONTAINS, ADJACENT_TO
+      KNOWLEDGE: KNOWS, KNOWS_ABOUT, LEARNED, DISCOVERED, FORGOT
+      MEMBERSHIP: MEMBER_OF, LEADS, FOUNDED, EXPELLED_FROM
+
+  source:
+    type: string
+    description: "Source node ID"
+
+  target:
+    type: string
+    description: "Target node ID"
+
+  valid_in:
+    type: array
+    items:
+      $ref: "#/$defs/TemporalScope"
+    description: "When this edge exists (frame + time range)"
+
+  properties:
+    type: object
+    description: "Weight, emotional valence, cause, etc."
+    additionalProperties: true
+    properties:
+      weight:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+      emotional:
+        type: object
+        properties:
+          valence:
+            type: number
+            minimum: -1.0
+            maximum: 1.0
+          arousal:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+      cause:
+        type: string
+        description: "Node ID of the event that caused this edge"
+
+  known_by:
+    type: array
+    items:
+      type: string
+    description: "Character node IDs that know about this edge. Empty = public knowledge"
+
+  referenced_in:
+    type: array
+    items:
+      $ref: "#/$defs/Reference"
+    description: "Derivations that reference this edge (auto-populated)"
+
+$defs:
+  TemporalScope:
+    type: object
+    required:
+      - frame
+    properties:
+      frame:
+        type: string
+        pattern: "^frame_"
+        description: "Temporal frame ID"
+      from:
+        type: string
+        pattern: "^T\\d+$"
+        description: "Start time point. null = since the beginning of the frame"
+      to:
+        type: string
+        pattern: "^T\\d+$"
+        description: "End time point. null = still active / ongoing"
+
+  Reference:
+    type: object
+    properties:
+      derivation_id:
+        type: string
+      file:
+        type: string

--- a/schemas/format.schema.yaml
+++ b/schemas/format.schema.yaml
@@ -1,0 +1,151 @@
+# Story as Code – Format Schema
+# Defines the structure of output format files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/format/v0.1.0"
+type: object
+required:
+  - id
+  - output_type
+  - structure
+
+properties:
+  id:
+    type: string
+    pattern: "^fmt_"
+    description: "Unique format identifier"
+
+  name:
+    type: string
+    description: "Human-readable format name"
+
+  output_type:
+    type: string
+    enum:
+      - TEXT
+      - SCREENPLAY
+      - COMIC
+      - AUDIO
+      - INTERACTIVE
+    description: >
+      TEXT: Prose fiction, articles, poetry.
+      SCREENPLAY: Film/TV script format.
+      COMIC: Panel descriptions with visual direction.
+      AUDIO: Narration with TTS markup.
+      INTERACTIVE: Branching narrative with choice points.
+
+  structure:
+    $ref: "#/$defs/Structure"
+
+  pacing:
+    type: object
+    description: "Pacing rules per structural level"
+    additionalProperties:
+      type: object
+      properties:
+        tension_shape:
+          type: string
+          enum:
+            - RISE_CLIMAX_RESOLVE
+            - MINI_ARC
+            - FLAT
+            - ESCALATING
+        cliffhanger_at_end:
+          type: boolean
+        end_hook:
+          type: string
+          enum:
+            - ALWAYS
+            - USUALLY
+            - SOMETIMES
+            - NEVER
+        min_graph_events:
+          type: integer
+          minimum: 0
+        max_new_nodes_introduced:
+          type: integer
+          minimum: 0
+
+  # --- Output-type-specific fields ---
+  comic:
+    type: object
+    description: "COMIC-specific settings"
+    properties:
+      panels_per_page:
+        type: integer
+      art_style_reference:
+        type: string
+      color_palette:
+        type: array
+        items:
+          type: string
+
+  audio:
+    type: object
+    description: "AUDIO-specific settings"
+    properties:
+      voice_profiles:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            voice_id:
+              type: string
+            pitch:
+              type: string
+            speed:
+              type: number
+
+  interactive:
+    type: object
+    description: "INTERACTIVE-specific settings"
+    properties:
+      choice_points:
+        type: array
+        items:
+          type: object
+          properties:
+            at:
+              type: string
+            options:
+              type: array
+              items:
+                type: object
+                properties:
+                  label:
+                    type: string
+                  graph_effects:
+                    type: array
+                    items:
+                      type: object
+
+$defs:
+  Structure:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+          - SERIES
+          - BOOK
+          - PART
+          - CHAPTER
+          - SCENE
+          - POST
+          - PANEL
+          - SEGMENT
+      count:
+        type: string
+        description: "Fixed number or range (e.g., '3' or '8-15')"
+      target_words:
+        type: string
+        description: "Word count target or range (e.g., '3000-5000')"
+      target_characters:
+        type: integer
+        description: "Character limit (e.g., 280 for tweets)"
+      children:
+        type: array
+        items:
+          $ref: "#/$defs/Structure"

--- a/schemas/frame.schema.yaml
+++ b/schemas/frame.schema.yaml
@@ -1,0 +1,109 @@
+# Story as Code – Temporal Frame Schema
+# Defines the structure of temporal frame files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/frame/v0.1.0"
+type: object
+required:
+  - id
+  - topology
+
+properties:
+  id:
+    type: string
+    pattern: "^frame_"
+    description: "Unique frame identifier"
+
+  topology:
+    type: string
+    enum:
+      - LINEAR
+      - BRANCHING
+      - CYCLICAL
+      - RETROCAUSAL
+      - SUBJECTIVE
+      - ENTROPIC
+    description: >
+      LINEAR: Standard sequential time.
+      BRANCHING: Diverged from another frame.
+      CYCLICAL: Time loop with iterations.
+      RETROCAUSAL: Effects in the past of another frame.
+      SUBJECTIVE: Time as experienced by a specific character.
+      ENTROPIC: Degrading time allowing contradictions.
+
+  parent_frame:
+    type: string
+    pattern: "^frame_"
+    description: "Parent frame ID for nested time contexts"
+
+  branch_origin:
+    type: string
+    description: "Event node ID where this frame branched from another"
+
+  loop_count:
+    type: integer
+    minimum: 1
+    description: "For CYCLICAL frames: which iteration"
+
+  observer:
+    type: string
+    pattern: "^char_"
+    description: "For SUBJECTIVE frames: character node experiencing this time"
+
+  entropy_factor:
+    type: number
+    minimum: 0.0
+    maximum: 1.0
+    description: "High values allow intentional inconsistencies"
+
+  time_mapping:
+    type: object
+    description: "Maps T-values to narrative time descriptions"
+    additionalProperties:
+      type: string
+
+  connections:
+    type: array
+    items:
+      $ref: "#/$defs/FrameConnection"
+
+$defs:
+  FrameConnection:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+          - BRANCHES_INTO
+          - BRANCHES_FROM
+          - RECEIVES_RETROCAUSAL
+          - SENDS_RETROCAUSAL
+          - LOOPS_BACK
+          - SUBJECTIVE_OF
+      target:
+        type: string
+        pattern: "^frame_"
+      source:
+        type: string
+        pattern: "^frame_"
+      at:
+        type: string
+        pattern: "^T\\d+$"
+      cause:
+        type: string
+        description: "Event node ID that triggered this connection"
+      affects_range:
+        type: array
+        items:
+          type: string
+          pattern: "^T\\d+$"
+        minItems: 2
+        maxItems: 2
+      status:
+        type: string
+        enum:
+          - PENDING
+          - ARRIVED
+          - RESOLVED

--- a/schemas/git-branch-meta.schema.yaml
+++ b/schemas/git-branch-meta.schema.yaml
@@ -1,0 +1,52 @@
+# Story as Code – Git Branch Metadata Schema
+# Defines the structure of .gitbranchmeta/*.yaml files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/git-branch-meta/v0.1.0"
+type: object
+required:
+  - type
+
+properties:
+  type:
+    type: string
+    enum:
+      - CANON
+      - SPECULATIVE
+      - RETCON
+      - FORK
+      - COLLAB
+    description: >
+      CANON: Main branch, the accepted truth.
+      SPECULATIVE: "What if" exploration.
+      RETCON: Retroactive change to established canon.
+      FORK: Independent version by another author.
+      COLLAB: Collaborator working on a section.
+
+  branch_point:
+    type: string
+    description: "Git commit hash where this branch diverged"
+
+  description:
+    type: string
+    description: "Human-readable description of the branch's purpose"
+
+  affects_frames:
+    type: array
+    items:
+      type: string
+      pattern: "^frame_"
+    description: "Temporal frames affected by this branch"
+
+  author:
+    type: string
+    description: "Author or collaborator name"
+
+  merge_strategy:
+    type: string
+    enum:
+      - PICK_A
+      - PICK_B
+      - FORK_FRAME
+      - MANUAL
+    description: "Preferred conflict resolution strategy"

--- a/schemas/lens.schema.yaml
+++ b/schemas/lens.schema.yaml
@@ -1,0 +1,221 @@
+# Story as Code – Lens Schema
+# Defines the structure of lens (narrative perspective) files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/lens/v0.1.0"
+type: object
+required:
+  - id
+  - perspective
+
+properties:
+  id:
+    type: string
+    pattern: "^lens_"
+    description: "Unique lens identifier"
+
+  type:
+    type: string
+    enum:
+      - SIMPLE
+      - COMPOSITE
+    default: SIMPLE
+
+  # --- Perspective (§5.1) ---
+  perspective:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+          - CHARACTER_BOUND
+          - OMNISCIENT
+          - OBJECTIVE
+          - CUSTOM
+      anchor:
+        type: string
+        description: "Node ID for CHARACTER_BOUND perspective"
+      person:
+        type: string
+        enum:
+          - FIRST
+          - SECOND
+          - THIRD
+
+  # --- Knowledge Filter (§5.2) ---
+  knowledge:
+    type: object
+    properties:
+      mode:
+        type: string
+        enum:
+          - OMNISCIENT
+          - CHARACTER_KNOWLEDGE
+          - PUBLIC_ONLY
+      source:
+        type: string
+        description: "Path to character's knowledge array"
+      include_subconscious:
+        type: boolean
+        default: false
+      include_wrong_beliefs:
+        type: boolean
+        default: false
+
+  # --- Temporal Position (§5.3) ---
+  temporal_position:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - IN_MOMENT
+          - RETROSPECTIVE
+          - PROPHETIC
+      narrating_from:
+        type: string
+        pattern: "^T\\d+$"
+        description: "For RETROSPECTIVE: time point from which the narrator looks back"
+      knows_future_until:
+        type: string
+        pattern: "^T\\d+$"
+
+  # --- Emotional Filter (§5.4) ---
+  emotional:
+    type: object
+    properties:
+      source:
+        type: string
+        enum:
+          - NEUTRAL
+          - CHARACTER_STATE
+          - CUSTOM
+      bias:
+        type: object
+        properties:
+          toward:
+            type: array
+            items:
+              type: string
+            description: "Node IDs whose relationships color the narrative"
+          bias_strength:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+
+  # --- Voice (§5.5) ---
+  voice:
+    type: object
+    properties:
+      vocabulary_level:
+        type: string
+        enum:
+          - LITERARY
+          - FORMAL
+          - COLLOQUIAL
+          - ARCHAIC
+          - MINIMAL
+      sentence_tendency:
+        type: string
+        enum:
+          - FLOWING
+          - SHORT_STACCATO
+          - COMPLEX_NESTED
+      inner_monologue:
+        type: boolean
+        default: true
+      metaphor_density:
+        type: string
+        enum:
+          - NONE
+          - LOW
+          - MEDIUM
+          - HIGH
+      verbal_tics:
+        type: array
+        items:
+          type: string
+      language_rendering:
+        type: object
+        properties:
+          mode:
+            type: string
+            enum:
+              - NATURALISTIC
+              - TRANSLATED_WITH_MARKERS
+              - INLINE_CONSTRUCTED
+              - FULL_CONLANG
+
+  # --- Reliability (§5.6) ---
+  reliability:
+    type: object
+    properties:
+      level:
+        type: string
+        enum:
+          - RELIABLE
+          - SELECTIVE
+          - UNRELIABLE
+          - LYING
+      omits:
+        type: array
+        items:
+          type: string
+        description: "Event IDs that this narrator skips or downplays"
+      distorts:
+        type: array
+        items:
+          type: object
+          properties:
+            node:
+              type: string
+            direction:
+              type: string
+              enum:
+                - POSITIVE
+                - NEGATIVE
+
+  # --- Composite Lens (§5.7) ---
+  layers:
+    type: array
+    description: "For COMPOSITE lenses: layered lens configuration"
+    items:
+      type: object
+      required:
+        - lens
+        - role
+      properties:
+        lens:
+          type: string
+          pattern: "^lens_"
+        role:
+          type: string
+          enum:
+            - BASE
+            - DIP
+            - OVERRIDE
+        trigger:
+          type: object
+          properties:
+            when:
+              type: string
+            node:
+              type: string
+
+  alternation:
+    type: object
+    description: "For COMPOSITE lenses: alternation configuration"
+    properties:
+      mode:
+        type: string
+        enum:
+          - PER_SCENE
+          - PER_CHAPTER
+          - FLUID
+      sequence:
+        type: array
+        items:
+          type: string
+          pattern: "^lens_"

--- a/schemas/node.schema.yaml
+++ b/schemas/node.schema.yaml
@@ -1,0 +1,80 @@
+# Story as Code – Node Schema
+# Defines the structure of node files (characters, locations, objects, events, concepts)
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/node/v0.1.0"
+type: object
+required:
+  - id
+  - type
+
+properties:
+  id:
+    type: string
+    pattern: "^(char|loc|obj|evt|con)_[a-z0-9_]+$"
+    description: "Unique identifier. Convention: {type_prefix}_{name}"
+
+  type:
+    type: string
+    enum:
+      - CHARACTER
+      - LOCATION
+      - OBJECT
+      - EVENT
+      - CONCEPT
+    description: "Node type. Can be extended by custom schemas."
+
+  schema:
+    type: string
+    pattern: "^schema_"
+    description: "Schema ID if type comes from a custom schema"
+
+  static:
+    type: object
+    description: "Properties that rarely change"
+    properties:
+      name_variants:
+        type: array
+        items:
+          type: string
+        description: "All names, aliases, pronouns for tagging resolution"
+      category:
+        type: string
+        description: "Free-form categorization (e.g., protagonist, antagonist)"
+
+  states:
+    type: array
+    items:
+      $ref: "#/$defs/NodeState"
+    description: "Temporal states of this node"
+
+  tags:
+    type: array
+    items:
+      type: string
+    description: "Free-form tags for filtering and organization"
+
+  created_at_commit:
+    type: string
+    description: "Git commit hash when this node was first created (auto-populated)"
+
+$defs:
+  NodeState:
+    type: object
+    required:
+      - frame
+      - at
+      - properties
+    properties:
+      frame:
+        type: string
+        pattern: "^frame_"
+        description: "ID of the temporal frame this state belongs to"
+      at:
+        type: string
+        pattern: "^T\\d+$"
+        description: "Time point identifier (e.g., T0, T12, T100)"
+      properties:
+        type: object
+        description: "Key-value pairs. Keys are free-form or schema-defined"
+        additionalProperties: true

--- a/schemas/schema.schema.yaml
+++ b/schemas/schema.schema.yaml
@@ -1,0 +1,110 @@
+# Story as Code – Schema Definition Schema
+# Defines the structure of user/community schema files
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/schema/v0.1.0"
+type: object
+required:
+  - id
+  - name
+  - version
+  - source
+
+properties:
+  id:
+    type: string
+    pattern: "^schema_"
+    description: "Unique schema identifier"
+
+  name:
+    type: string
+    description: "Human-readable name"
+
+  version:
+    type: integer
+    minimum: 1
+    description: "Schema version (incremented on changes)"
+
+  source:
+    type: string
+    enum:
+      - BUILTIN
+      - COMMUNITY
+      - USER_DEFINED
+    description: "Origin of the schema"
+
+  maturity:
+    type: string
+    enum:
+      - IMPLICIT
+      - SKETCH
+      - STRUCTURED
+      - RIGOROUS
+    default: SKETCH
+    description: "Maturity level determining validation strictness"
+
+  depends_on:
+    type: array
+    items:
+      type: string
+      pattern: "^schema_"
+    description: "Other schemas this one requires"
+
+  node_types:
+    type: object
+    description: "New node type definitions"
+    additionalProperties:
+      $ref: "#/$defs/TypeDefinition"
+
+  edge_types:
+    type: object
+    description: "New edge type definitions"
+    additionalProperties:
+      $ref: "#/$defs/EdgeTypeDefinition"
+
+$defs:
+  TypeDefinition:
+    type: object
+    properties:
+      description:
+        type: string
+      properties:
+        type: object
+        additionalProperties:
+          $ref: "#/$defs/PropertyDefinition"
+
+  EdgeTypeDefinition:
+    type: object
+    properties:
+      description:
+        type: string
+      source_type:
+        type: string
+        description: "Allowed source node type"
+      target_type:
+        type: string
+        description: "Allowed target node type"
+      properties:
+        type: object
+        additionalProperties:
+          $ref: "#/$defs/PropertyDefinition"
+
+  PropertyDefinition:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        description: >
+          Property type. Supported values:
+          STRING, INTEGER, FLOAT, BOOLEAN,
+          ENUM[value1, value2, ...],
+          LIST<T>, REFERENCE, TEMPORAL, VECTOR, OBJECT
+      default:
+        description: "Default value for this property"
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false

--- a/schemas/schema_core.yaml
+++ b/schemas/schema_core.yaml
@@ -1,0 +1,161 @@
+# Story as Code – Core Schema
+# Built-in types that are always present in every Story as Code world
+# Spec Version: 0.1.0
+
+id: schema_core
+name: "Core Types"
+version: 1
+source: BUILTIN
+maturity: RIGOROUS
+
+node_types:
+  CHARACTER:
+    description: "A sentient being: person, creature, AI, deity"
+    prefix: "char_"
+    properties:
+      name_variants:
+        type: LIST<STRING>
+        required: true
+        description: "All names, aliases, pronouns for tagging resolution"
+      category:
+        type: STRING
+        description: "Free-form categorization (e.g., protagonist, antagonist, supporting)"
+      age:
+        type: INTEGER
+        description: "Age of the character at a given time point"
+      emotional_baseline:
+        type: OBJECT
+        description: "Default emotional state: {valence: FLOAT, arousal: FLOAT}"
+      moral_alignment:
+        type: FLOAT
+        description: "-1.0 (evil) to 1.0 (good)"
+      knowledge:
+        type: LIST<REFERENCE>
+        description: "List of node IDs this character knows about"
+
+  LOCATION:
+    description: "A place: room, city, planet, abstract space"
+    prefix: "loc_"
+    properties:
+      name_variants:
+        type: LIST<STRING>
+        required: true
+      coordinates:
+        type: OBJECT
+        description: "Optional spatial coordinates within a map system"
+      climate:
+        type: STRING
+      population:
+        type: INTEGER
+
+  OBJECT:
+    description: "A physical or conceptual thing: sword, letter, treaty"
+    prefix: "obj_"
+    properties:
+      name_variants:
+        type: LIST<STRING>
+        required: true
+      category:
+        type: STRING
+        description: "weapon, document, artifact, currency, etc."
+      is_unique:
+        type: BOOLEAN
+        default: true
+
+  EVENT:
+    description: "A discrete occurrence: battle, meeting, death"
+    prefix: "evt_"
+    properties:
+      name_variants:
+        type: LIST<STRING>
+        required: true
+      severity:
+        type: FLOAT
+        description: "0.0 (trivial) to 1.0 (world-altering)"
+      participants:
+        type: LIST<REFERENCE>
+        description: "Node IDs of characters involved"
+      location:
+        type: REFERENCE
+        description: "Location node ID where this event occurred"
+
+  CONCEPT:
+    description: "An abstract idea: honor, magic, fate"
+    prefix: "con_"
+    properties:
+      name_variants:
+        type: LIST<STRING>
+        required: true
+      domain:
+        type: STRING
+        description: "philosophical, magical, political, religious, etc."
+
+edge_types:
+  RELATIONSHIP:
+    description: "Interpersonal or inter-entity connection"
+    subtypes:
+      - LOVES
+      - HATES
+      - TRUSTS
+      - FEARS
+      - SERVES
+      - MENTORS
+      - RIVALS
+    properties:
+      weight:
+        type: FLOAT
+        description: "0.0 to 1.0 intensity"
+      emotional:
+        type: OBJECT
+        description: "{valence: FLOAT, arousal: FLOAT}"
+      cause:
+        type: REFERENCE
+        description: "Event that caused this relationship"
+
+  ACTION:
+    description: "Something one node did to another"
+    subtypes:
+      - CREATED
+      - DESTROYED
+      - VISITED
+      - STOLE
+      - GAVE
+      - KILLED
+      - SAVED
+    properties:
+      cause:
+        type: REFERENCE
+      result:
+        type: REFERENCE
+
+  SPATIAL:
+    description: "Spatial relationship between nodes"
+    subtypes:
+      - LOCATED_AT
+      - PART_OF
+      - CONTAINS
+      - ADJACENT_TO
+
+  KNOWLEDGE:
+    description: "Information flow between nodes"
+    subtypes:
+      - KNOWS
+      - KNOWS_ABOUT
+      - LEARNED
+      - DISCOVERED
+      - FORGOT
+    properties:
+      certainty:
+        type: FLOAT
+        description: "0.0 (rumor) to 1.0 (witnessed)"
+
+  MEMBERSHIP:
+    description: "Group or organizational relationships"
+    subtypes:
+      - MEMBER_OF
+      - LEADS
+      - FOUNDED
+      - EXPELLED_FROM
+    properties:
+      rank:
+        type: STRING

--- a/schemas/world.schema.yaml
+++ b/schemas/world.schema.yaml
@@ -1,0 +1,45 @@
+# Story as Code – World Metadata Schema
+# Defines the structure of the root world.yaml file
+# Spec Version: 0.1.0
+
+$schema: "https://story-as-code.dev/schemas/world/v0.1.0"
+type: object
+required:
+  - spec_version
+  - name
+  - created_at
+  - default_frame
+
+properties:
+  spec_version:
+    type: string
+    pattern: "^\\d+\\.\\d+\\.\\d+$"
+    description: "Semantic version of the Story as Code spec this world conforms to"
+
+  name:
+    type: string
+    description: "Human-readable name of the world"
+
+  created_at:
+    type: string
+    format: date-time
+    description: "ISO 8601 timestamp of world creation"
+
+  default_frame:
+    type: string
+    pattern: "^frame_"
+    description: "ID of the default temporal frame"
+
+  settings:
+    type: object
+    properties:
+      default_language:
+        type: string
+        description: "ISO 639-1 language code"
+      embedding_model:
+        type: string
+        description: "Model identifier for semantic embeddings"
+      embedding_dimensions:
+        type: integer
+        minimum: 1
+        description: "Dimensionality of embedding vectors"


### PR DESCRIPTION
## Summary
- Add 12 YAML schema files defining the Story as Code data model (nodes, edges, frames, arcs, lenses, formats, constraints, worlds, etc.)
- Remove manual `spec.md` nav entry from mkdocs.yml — schema documentation is auto-generated by the `schema_reader` plugin
- Fixes the 404 on `/spec.md` by replacing it with plugin-generated schema pages

## Test plan
- [x] Verify `mkdocs build` succeeds with the new schema files
- [x] Verify schema pages appear in the generated docs navigation
- [ ] Verify no more 404 on the specification pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)