### PR TITLE
fix(docs): add schema pages to mkdocs navigation

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install MkDocs Material and plugins
-        run: pip install mkdocs-material mkdocs-include-markdown-plugin mkdocs-schema-reader
+        run: pip install mkdocs-material mkdocs-include-markdown-plugin mkdocs-literate-nav mkdocs-schema-reader
 
       - name: Build site
         run: mkdocs build

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ theme:
 plugins:
   - search
   - include-markdown
+  - literate-nav
   - schema_reader:
       include:
         - "schemas"
@@ -51,19 +52,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Schema:
-      - Core: schema/schema_core.md
-      - Meta Schema: schema/schema.md
-      - World: schema/world.md
-      - Node: schema/node.md
-      - Edge: schema/edge.md
-      - Frame: schema/frame.md
-      - Arc: schema/arc.md
-      - Lens: schema/lens.md
-      - Format: schema/format.md
-      - Constraint: schema/constraint.md
-      - Derivation Meta: schema/derivation-meta.md
-      - Git Branch Meta: schema/git-branch-meta.md
+  - Schema: schema/
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md
   - License: license.md


### PR DESCRIPTION
## Summary
- Add `mkdocs-literate-nav` plugin for automatic schema page discovery
- Replace manually listed schema nav entries with directory-based auto-discovery (`schema/`)
- Add plugin to CI pip install in deploy-pages workflow

New schemas are now automatically included in the docs navigation without updating mkdocs.yml.

## Test plan
- [ ] Verify schema pages appear under "Schema" section in docs navigation
- [ ] Verify adding a new schema file does not require mkdocs.yml changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)