### PR TITLE
refactor: decouple schema from git, broaden scope, clarify outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,20 @@
 [![GitHub Pages](https://img.shields.io/badge/Docs-GitHub_Pages-brightgreen.svg)](https://christopherscholz.github.io/story-as-code-spec/)
 
 <!-- content-start -->
-> Declarative YAML specification for defining fictional worlds as temporal graphs and deriving narratives from them.
+> Declarative YAML specification for defining worlds as temporal graphs and deriving outputs from them.
 
 ## What is Story as Code?
 
-Story as Code treats fictional worlds as **source code** — structured, versioned, and compilable. Instead of writing narratives directly, you declare a world graph of characters, locations, events, and their relationships. Narratives are then **derived** from this graph through lenses, arcs, and formats.
+Story as Code treats worlds as **source code** — structured, versioned, and compilable. Instead of writing stories directly, you declare a world graph of characters, locations, events, and their relationships. Outputs are then **derived** from this graph through lenses, arcs, and output formats — e.g. tweets, short stories, comic panels, books, screenplays, and more.
 
-Think of it like a compiler: the world graph is your source, the narrative is your compiled output.
+Think of it like a compiler: the world graph is your source, the output is your compiled result.
 
 ### Core Principles
 
-- **Git-native** — Worlds are Git repositories with semantic commit conventions
-- **Declarative** — The graph declares what exists and when; narratives are derived, never primary
+- **Declarative** — The graph declares what exists and when; outputs are derived, never primary
 - **Temporally rich** — Time is graph topology, supporting branches, loops, and retrocausality
 - **Schema-flexible** — The type system is extensible for custom world rules
-- **Format-agnostic** — Same world can produce prose, screenplays, comics, audio, or interactive narratives
+- **Format-agnostic** — Same world can produce tweets, prose, screenplays, comics, audio, or interactive experiences
 
 ## Key Concepts
 
@@ -30,8 +29,8 @@ Think of it like a compiler: the world graph is your source, the narrative is yo
 | **Frames** | Temporal contexts with different topologies (linear, branching, cyclical) |
 | **Lenses** | Narrative perspective configurations — who tells the story, how, and what they know |
 | **Arcs** | Dramatic structure definitions with milestones and conditions |
-| **Formats** | Output structure (novel, screenplay, comic) with pacing rules |
-| **Derivations** | Compiled narrative outputs linked back to the graph |
+| **Formats** | Output format definitions (tweet, short story, comic panel, book, screenplay, ...) with pacing rules |
+| **Derivations** | Compiled outputs linked back to the graph |
 
 ## Quick Start
 
@@ -86,7 +85,7 @@ constraints/                 # World rules
 lenses/                      # Narrative perspective configs
 arcs/                        # Story arc definitions
 formats/                     # Output format definitions
-derivations/                 # Generated narrative content
+derivations/                 # Generated output content
 ```
 
 ## Status

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Story as Code Spec
-site_description: Declarative YAML specification for defining fictional worlds as temporal graphs and deriving narratives from them
+site_description: Declarative YAML specification for defining worlds as temporal graphs and deriving outputs from them
 site_url: https://christopherscholz.github.io/story-as-code-spec/
 repo_url: https://github.com/christopherscholz/story-as-code-spec
 repo_name: christopherscholz/story-as-code-spec
@@ -52,7 +52,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Schema: schema/
+  - Schemas: schemas/
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md
   - License: license.md

--- a/schemas/derivation-meta.schema.yaml
+++ b/schemas/derivation-meta.schema.yaml
@@ -6,7 +6,6 @@ $schema: "https://story-as-code.dev/schemas/derivation-meta/v0.1.0"
 type: object
 required:
   - id
-  - derived_from_commit
   - derived_at
   - lens
   - format
@@ -17,9 +16,9 @@ properties:
     type: string
     description: "Derivation identifier"
 
-  derived_from_commit:
+  source_version:
     type: string
-    description: "Git commit hash of the graph state used"
+    description: "Version or identifier of the graph state used for this derivation"
 
   derived_at:
     type: string
@@ -87,7 +86,8 @@ properties:
           - BROKEN
       last_checked:
         type: string
-        description: "Commit hash of last validation"
+        format: date-time
+        description: "Timestamp of last validation"
       issues:
         type: array
         items:

--- a/schemas/node.schema.yaml
+++ b/schemas/node.schema.yaml
@@ -54,9 +54,10 @@ properties:
       type: string
     description: "Free-form tags for filtering and organization"
 
-  created_at_commit:
+  created_at:
     type: string
-    description: "Git commit hash when this node was first created (auto-populated)"
+    format: date-time
+    description: "Timestamp when this node was first created (auto-populated)"
 
 $defs:
   NodeState:

--- a/schemas/variant-meta.schema.yaml
+++ b/schemas/variant-meta.schema.yaml
@@ -1,8 +1,8 @@
-# Story as Code – Git Branch Metadata Schema
-# Defines the structure of .gitbranchmeta/*.yaml files
+# Story as Code – Variant Metadata Schema
+# Defines the structure of variant metadata files for parallel world versions
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/git-branch-meta/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/variant-meta/v0.1.0"
 type: object
 required:
   - type
@@ -17,26 +17,26 @@ properties:
       - FORK
       - COLLAB
     description: >
-      CANON: Main branch, the accepted truth.
+      CANON: Primary version, the accepted truth.
       SPECULATIVE: "What if" exploration.
       RETCON: Retroactive change to established canon.
       FORK: Independent version by another author.
       COLLAB: Collaborator working on a section.
 
-  branch_point:
+  parent_variant:
     type: string
-    description: "Git commit hash where this branch diverged"
+    description: "Identifier of the variant this one diverged from"
 
   description:
     type: string
-    description: "Human-readable description of the branch's purpose"
+    description: "Human-readable description of this variant's purpose"
 
   affects_frames:
     type: array
     items:
       type: string
       pattern: "^frame_"
-    description: "Temporal frames affected by this branch"
+    description: "Temporal frames affected by this variant"
 
   author:
     type: string


### PR DESCRIPTION
## Summary

- **Git-Entkopplung**: Alle git-spezifischen Referenzen aus Schemas entfernt (`created_at_commit` → `created_at`, `derived_from_commit` → `source_version`, `git-branch-meta.schema.yaml` → `variant-meta.schema.yaml`)
- **Scope erweitert**: "fictional" entfernt — die Spec gilt für beliebige Welten, nicht nur fiktive
- **Outputs statt Narratives**: "Narratives" durchgehend als "Outputs" reframed, mit konkreten Output-Formaten (Tweets, Short Stories, Comic Panels, Books, Screenplays)
- **mkdocs fix**: Nav-Pfad `schema/` → `schemas/` korrigiert

## Test plan

- [ ] `mkdocs serve` lokal starten und Navigation prüfen
- [ ] Schema-Seiten unter `/schemas/` erreichbar
- [ ] README-Inhalt auf docs index-Seite korrekt gerendert

🤖 Generated with [Claude Code](https://claude.com/claude-code)