### PR TITLE
feat: versioned docs with mike and resolvable schema URLs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,21 +2,12 @@ name: Deploy Docs to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "CODE_OF_CONDUCT.md"
-      - "LICENSE"
-      - "schemas/**"
-      - "requirements.txt"
+    tags: ['v*']
+    branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -25,33 +16,88 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install MkDocs Material and plugins
-        run: pip install -r requirements.txt
-
-      - name: Build site
-        run: mkdocs build
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site/
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Configure git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "alias=latest" >> "$GITHUB_OUTPUT"
+            echo "is_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+            echo "alias=" >> "$GITHUB_OUTPUT"
+            echo "is_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # mike deploys versioned docs to the gh-pages branch
+      - name: Deploy versioned docs with mike
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ALIAS="${{ steps.version.outputs.alias }}"
+
+          if [ -n "$ALIAS" ]; then
+            mike deploy --push --update-aliases "$VERSION" "$ALIAS"
+            mike set-default latest --push
+          else
+            mike deploy --push "$VERSION"
+          fi
+
+      # For tagged releases: add raw schema files to gh-pages
+      - name: Add schemas to gh-pages
+        if: steps.version.outputs.is_tag == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Save schemas from main before switching branches
+          mkdir -p /tmp/schemas
+          cp schemas/*.schema.yaml /tmp/schemas/
+
+          # Switch to gh-pages to add schema files
+          git checkout gh-pages
+
+          mkdir -p "schemas/v${VERSION}"
+          cp /tmp/schemas/*.schema.yaml "schemas/v${VERSION}/"
+
+          git add "schemas/v${VERSION}/"
+          git commit -m "Add raw schemas for v${VERSION}"
+          git push origin gh-pages
+
+      # Checkout gh-pages content and deploy via GitHub Actions Pages
+      - name: Prepare pages artifact
+        run: |
+          git checkout gh-pages
+          mkdir -p _site
+          # Copy everything except git metadata
+          rsync -a --exclude='.git' --exclude='_site' . _site/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+story-as-code.dev

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Story as Code Spec
 site_description: Declarative YAML specification for defining worlds as temporal graphs and deriving outputs from them
-site_url: https://christopherscholz.github.io/story-as-code-spec/
+site_url: https://story-as-code.dev/
 repo_url: https://github.com/christopherscholz/story-as-code-spec
 repo_name: christopherscholz/story-as-code-spec
 edit_uri: edit/main/
@@ -68,6 +68,10 @@ nav:
   - License: license.md
 
 extra:
+  version:
+    provider: mike
+    default:
+      - latest
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/christopherscholz/story-as-code-spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=1.6,<2.0
 mkdocs-material>=9,<10
 mkdocs-include-markdown-plugin
 mkdocs-literate-nav
+mike>=2.0,<3.0

--- a/schemas/arc.schema.yaml
+++ b/schemas/arc.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of story arc files
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/arc/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/arc.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/constraint.schema.yaml
+++ b/schemas/constraint.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of constraint (world rule) files
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/constraint/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/constraint.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/derivation-meta.schema.yaml
+++ b/schemas/derivation-meta.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of .meta.yaml files (validation contracts)
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/derivation-meta/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/derivation-meta.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/edge.schema.yaml
+++ b/schemas/edge.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of edge files (relationships between nodes)
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/edge/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/edge.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/format.schema.yaml
+++ b/schemas/format.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of output format files
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/format/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/format.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/frame.schema.yaml
+++ b/schemas/frame.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of temporal frame files
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/frame/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/frame.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/lens.schema.yaml
+++ b/schemas/lens.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of lens (narrative perspective) files
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/lens/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/lens.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/node.schema.yaml
+++ b/schemas/node.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of node files (characters, locations, objects, events, concepts)
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/node/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/node.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/schema.schema.yaml
+++ b/schemas/schema.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of user/community schema files
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/schema/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/schema.schema.yaml"
 type: object
 required:
   - id

--- a/schemas/variant-meta.schema.yaml
+++ b/schemas/variant-meta.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of variant metadata files for parallel world versions
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/variant-meta/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/variant-meta.schema.yaml"
 type: object
 required:
   - type

--- a/schemas/world.schema.yaml
+++ b/schemas/world.schema.yaml
@@ -2,7 +2,7 @@
 # Defines the structure of the root world.yaml file
 # Spec Version: 0.1.0
 
-$schema: "https://story-as-code.dev/schemas/world/v0.1.0"
+$schema: "https://story-as-code.dev/schemas/v0.1.0/world.schema.yaml"
 type: object
 required:
   - spec_version


### PR DESCRIPTION
## Summary

- **Versioned documentation** via [mike](https://github.com/jimporter/mike): git tags (`v0.1.0`) deploy versioned docs, pushes to `main` deploy as `dev`
- **Resolvable schema URLs**: raw YAML schemas served at `https://story-as-code.dev/schemas/v0.1.0/{name}.schema.yaml` — matching the `$id` in each schema file
- **Custom domain**: CNAME + `site_url` configured for `story-as-code.dev`
- **Version selector**: MkDocs Material version switcher dropdown in the docs UI

## How it works

| Trigger | Version | URL |
|---------|---------|-----|
| `git tag v0.1.0 && git push --tags` | `0.1.0` (alias: `latest`) | `/0.1.0/`, `/latest/` |
| `git push main` | `dev` | `/dev/` |

## Prerequisites

Before merging, configure:
1. DNS A/AAAA/CNAME records at Hetzner pointing to GitHub Pages
2. GitHub repo Settings → Pages → Custom domain: `story-as-code.dev` + Enforce HTTPS

## Test plan

- [ ] Verify DNS propagation after Hetzner configuration
- [ ] Merge PR, then tag `v0.1.0` and push tag
- [ ] Confirm docs deploy at `https://story-as-code.dev/0.1.0/`
- [ ] Confirm schema files resolve at `https://story-as-code.dev/schemas/v0.1.0/world.schema.yaml`
- [ ] Confirm version selector dropdown appears in docs UI
- [ ] Push to main and verify `dev` version deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)