### PR TITLE
fix: set dev as default pages redirect when no release exists

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -57,6 +57,10 @@ jobs:
             mike set-default latest --push
           else
             mike deploy --push "$VERSION"
+            # Set dev as default if no latest version exists yet
+            if ! mike list | grep -q '\[latest\]'; then
+              mike set-default dev --push
+            fi
           fi
 
       - name: Add schemas to gh-pages


### PR DESCRIPTION
## Summary
- Root URL (https://christopherscholz.github.io/story-as-code-spec/) returns 404 because `mike set-default` is only called for tag releases
- Now sets `dev` as default redirect when no `latest` alias exists yet
- Once a tag release is created, `latest` takes over as default

## Test plan
- [ ] Merge and verify root URL redirects to `/dev/`
- [ ] Later: create a tag release and verify root URL redirects to `/latest/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)