### PR TITLE
fix: use --set-default flag to avoid gh-pages push conflict

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -53,13 +53,13 @@ jobs:
           ALIAS="${{ steps.version.outputs.alias }}"
 
           if [ -n "$ALIAS" ]; then
-            mike deploy --push --update-aliases "$VERSION" "$ALIAS"
-            mike set-default latest --push
+            mike deploy --push --update-aliases --set-default "$VERSION" "$ALIAS"
           else
-            mike deploy --push "$VERSION"
             # Set dev as default if no latest version exists yet
-            if ! mike list | grep -q '\[latest\]'; then
-              mike set-default dev --push
+            if mike list | grep -q '\[latest\]'; then
+              mike deploy --push "$VERSION"
+            else
+              mike deploy --push --set-default "$VERSION"
             fi
           fi
 


### PR DESCRIPTION
## Summary
- `mike deploy --push` followed by `mike set-default --push` fails because the second command's local `gh-pages` is stale after the first push
- Uses `--set-default` flag on `mike deploy` to combine both operations into a single push
- Applies to both tag releases (`latest`) and dev builds (`dev` as fallback default)

## Test plan
- [ ] Merge and verify the deploy workflow succeeds
- [ ] Verify root URL redirects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)