### PR TITLE
fix: use --ignore-remote-status for mike set-default

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -53,13 +53,13 @@ jobs:
           ALIAS="${{ steps.version.outputs.alias }}"
 
           if [ -n "$ALIAS" ]; then
-            mike deploy --push --update-aliases --set-default "$VERSION" "$ALIAS"
+            mike deploy --push --update-aliases "$VERSION" "$ALIAS"
+            mike set-default --push --ignore-remote-status latest
           else
+            mike deploy --push "$VERSION"
             # Set dev as default if no latest version exists yet
-            if mike list | grep -q '\[latest\]'; then
-              mike deploy --push "$VERSION"
-            else
-              mike deploy --push --set-default "$VERSION"
+            if ! mike list | grep -q '\[latest\]'; then
+              mike set-default --push --ignore-remote-status dev
             fi
           fi
 


### PR DESCRIPTION
## Summary
- `--set-default` is not a valid flag for `mike deploy` — fixes the broken workflow from #11
- Reverts to separate `mike set-default` calls but adds `--ignore-remote-status` so the second push doesn't fail due to stale local `gh-pages` branch

## Test plan
- [ ] Merge and verify deploy workflow succeeds
- [ ] Verify root URL redirects to `/dev/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)