### PR TITLE
fix: fetch gh-pages before mike deploy instead of ignoring remote

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages || true
+
       - name: Determine version
         id: version
         run: |
@@ -51,16 +54,15 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           ALIAS="${{ steps.version.outputs.alias }}"
-          MIKE_OPTS="--push --ignore-remote-status"
 
           if [ -n "$ALIAS" ]; then
-            mike deploy $MIKE_OPTS --update-aliases "$VERSION" "$ALIAS"
-            mike set-default $MIKE_OPTS latest
+            mike deploy --push --update-aliases "$VERSION" "$ALIAS"
+            mike set-default --push latest
           else
-            mike deploy $MIKE_OPTS "$VERSION"
+            mike deploy --push "$VERSION"
             # Set dev as default if no latest version exists yet
             if ! mike list | grep -q '\[latest\]'; then
-              mike set-default $MIKE_OPTS dev
+              mike set-default --push dev
             fi
           fi
 
@@ -69,7 +71,6 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          # Use a worktree so we don't disturb the main checkout
           git fetch origin gh-pages
           git worktree add /tmp/gh-pages origin/gh-pages
 


### PR DESCRIPTION
## Summary
- `--ignore-remote-status` was **skipping** the remote fetch, not forcing it — this caused every `mike deploy --push` to be rejected because it pushed against a stale `gh-pages` base
- Now explicitly fetches `gh-pages:gh-pages` before any mike operation so mike's internal `update_from_upstream` works correctly
- Removes `--ignore-remote-status` from all mike commands

## Root cause
`actions/checkout` with `fetch-depth: 0` only fetches full history for the checked-out branch (`main`), not `gh-pages`. Mike needs a local `gh-pages` branch to merge against before pushing.

## Test plan
- [ ] Merge and verify deploy workflow succeeds
- [ ] Verify root URL redirects to `/dev/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)